### PR TITLE
Add basic HTML report option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ The tool supports various command line arguments for customization:
 python main.py --help
 ```
 
+Common examples:
+
+```bash
+python main.py --save    # generate PDF report
+python main.py --html    # generate interactive HTML report
+```
+
 ## Output
 
 The analyzer generates:

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ import math
 import argparse
 import re
 from contextlib import redirect_stdout
+import html
 
 warnings.filterwarnings('ignore')
 try:
@@ -2623,8 +2624,104 @@ def save_analysis_to_pdf(content, filename="portfolio_analysis.pdf"):
         print(f"❌ Error generating PDF: {e}")
         return False
 
-def capture_analysis_output():
-    """Capture all analysis output to a string"""
+def save_analysis_to_html(content, metrics, analyzer, filename="portfolio_analysis.html"):
+    """Save the analysis content and interactive charts to an HTML file"""
+
+    print(f"\n💾 Generating HTML report: {filename}")
+
+    try:
+        holdings_df = pd.DataFrame(metrics.get('holdings_summary', []))
+        if not holdings_df.empty:
+            table_html = holdings_df[
+                ['symbol', 'quantity', 'current_value', 'unrealized_gain_pct']
+            ].to_html(index=False, float_format=lambda x: f"{x:,.2f}")
+        else:
+            table_html = "<p>No holdings data available.</p>"
+
+        sectors = list(metrics.get('sector_allocation', {}).keys())
+        values = list(metrics.get('sector_allocation', {}).values())
+        charts = []
+        if sectors and values:
+            fig = px.pie(names=sectors, values=values, title="Sector Allocation")
+            charts.append(pio.to_html(fig, include_plotlyjs='cdn', full_html=False))
+
+        # Portfolio performance over time vs benchmark
+        portfolio_series = []
+        for symbol, holding in analyzer.holdings.items():
+            hist = analyzer.historical_data.get(symbol, pd.DataFrame())
+            if hist.empty or 'Close' not in hist:
+                continue
+            df = hist[['Close']].rename(columns={'Close': symbol}) * holding['quantity']
+            portfolio_series.append(df)
+
+        if portfolio_series:
+            combined = pd.concat(portfolio_series, axis=1).fillna(method='ffill')
+            combined['Portfolio'] = combined.sum(axis=1)
+            if hasattr(analyzer, 'benchmark_data') and not getattr(analyzer, 'benchmark_data', pd.DataFrame()).empty:
+                bench = analyzer.benchmark_data[['Close']].rename(columns={'Close': 'Benchmark'})
+                combined = combined.join(bench, how='inner')
+            line_df = combined[['Portfolio'] + (["Benchmark"] if 'Benchmark' in combined.columns else [])].dropna().reset_index()
+            line_df.rename(columns={'index': 'Date'}, inplace=True)
+            fig_line = px.line(line_df, x='Date', y=line_df.columns[1:], title='Portfolio Performance')
+            charts.append(pio.to_html(fig_line, include_plotlyjs='cdn', full_html=False))
+
+        # Risk-return scatter plot
+        risk_data = []
+        for symbol, hist in analyzer.historical_data.items():
+            if hist.empty or 'Close' not in hist:
+                continue
+            returns = hist['Close'].pct_change().dropna()
+            if returns.empty:
+                continue
+            volatility = returns.std() * np.sqrt(252)
+            cumulative = (1 + returns).prod() - 1
+            risk_data.append({'Symbol': symbol, 'Volatility': volatility * 100, 'Return': cumulative * 100})
+
+        if risk_data:
+            risk_df = pd.DataFrame(risk_data)
+            fig_scatter = px.scatter(risk_df, x='Volatility', y='Return', text='Symbol', title='Risk vs Return')
+            charts.append(pio.to_html(fig_scatter, include_plotlyjs='cdn', full_html=False))
+
+        # Treemap of portfolio composition
+        if not holdings_df.empty and 'sector' in holdings_df.columns:
+            fig_tree = px.treemap(holdings_df, path=['sector', 'symbol'], values='current_value', title='Portfolio Composition')
+            charts.append(pio.to_html(fig_tree, include_plotlyjs='cdn', full_html=False))
+
+        charts_html = "\n".join(charts) if charts else "<p>No chart data available.</p>"
+
+        html_content = f"""
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>Portfolio Analysis Report</title>
+    <style>body{{font-family:Arial, sans-serif;}}</style>
+</head>
+<body>
+    <h1>Portfolio Analysis Report</h1>
+    <pre>{html.escape(content)}</pre>
+    <h2>Holdings Summary</h2>
+    {table_html}
+    <h2>Interactive Charts</h2>
+    {charts_html}
+</body>
+</html>
+"""
+
+        # Write using UTF-8 to handle emojis and other unicode characters
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write(html_content)
+        print(f"✅ HTML report saved successfully: {filename}")
+        return True
+    except Exception as e:
+        print(f"❌ Error generating HTML: {e}")
+        return False
+
+def capture_analysis_output(return_metrics: bool = False, return_analyzer: bool = False):
+    """Capture all analysis output to a string.
+
+    If ``return_metrics`` is True, return the metrics dictionary as well.
+    If ``return_analyzer`` is True, return the analyzer instance.
+    """
     
     output_buffer = io.StringIO()
     
@@ -2712,7 +2809,14 @@ def capture_analysis_output():
         
         # Get the captured output
         content = output_buffer.getvalue()
-        return content
+        results = [content]
+        if return_metrics:
+            results.append(metrics)
+        if return_analyzer:
+            results.append(analyzer)
+        if len(results) == 1:
+            return results[0]
+        return tuple(results)
         
     except Exception as e:
         return f"❌ Error capturing analysis: {e}"
@@ -2723,8 +2827,10 @@ def main():
     """Main function with command line argument parsing"""
     
     parser = argparse.ArgumentParser(description='Portfolio Analysis Tool')
-    parser.add_argument('--save', action='store_true', 
+    parser.add_argument('--save', action='store_true',
                        help='Save analysis to PDF file in addition to console output')
+    parser.add_argument('--html', action='store_true',
+                       help='Save analysis to interactive HTML report')
     
     args = parser.parse_args()
     
@@ -2743,7 +2849,21 @@ def main():
         
         if success:
             print(f"\n📁 Analysis saved to: {filename}")
-    else:
+
+    if args.html:
+        print("🔄 Running analysis and capturing output for HTML...")
+        content, metrics, analyzer = capture_analysis_output(return_metrics=True, return_analyzer=True)
+
+        print(content)
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        html_filename = f"portfolio_analysis_{timestamp}.html"
+        success_html = save_analysis_to_html(content, metrics, analyzer, html_filename)
+
+        if success_html:
+            print(f"\n📁 Analysis saved to: {html_filename}")
+
+    if not (args.save or args.html):
         # Just run normal console analysis
         display_comprehensive_portfolio_analysis()
 


### PR DESCRIPTION
## Summary
- generate simple HTML report with Plotly pie chart
- allow capturing metrics from analysis
- add `--html` CLI option
- fix HTML report encoding issue

## Testing
- `python -m py_compile main.py`
- `python main.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_686b3bac611c832ead49ce79c7fbb100